### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-readme-download-links.yml
+++ b/.github/workflows/update-readme-download-links.yml
@@ -1,4 +1,6 @@
 name: Update download links
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/MartinHlavna/hector/security/code-scanning/1](https://github.com/MartinHlavna/hector/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: write` is needed because the workflow modifies and pushes changes to the repository (`README.md`).
- No other permissions are required, so they will not be included.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
